### PR TITLE
fix: SECRET_PATH与url中其余部分有重叠时导致文本被截断

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const server = http.createServer((req, res) => {
   }
 
   // 解析原始请求 URL
-  req.url = req.url.split(kSecretPath)[1];
+  req.url = req.url.replace(`/${kSecretPath}`, "");
   const { pathname } = new URL("http://127.0.0.1" + req.url);
   const filePath = `public${pathname}`;
 


### PR DESCRIPTION
我在SECRET_PATH设置为x时，无意间发现text查询参数被截断，改为只替换字符串最先出现的部分